### PR TITLE
Update deps & run `deno fmt`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,20 +1,16 @@
+# 1.0.2 / 2020-07-14
 
-1.0.2 / 2020-07-14
-==================
+- fix test deps version
+- chore: fixed version deps
+- add hits
+- doc: fix doc, should be for Deno
 
-  * fix test deps version
-  * chore: fixed version deps
-  * add hits
-  * doc: fix doc, should be for Deno
+# 1.0.1 / 2020-05-23
 
-1.0.1 / 2020-05-23
-==================
+- License: fix copyright
+- chores: update path to deno.land/x
 
-  * License: fix copyright
-  * chores: update path to deno.land/x
+# 1.0.0 / 2020-05-21
 
-1.0.0 / 2020-05-21
-==================
-
-  * fix: use gh source
-  * init
+- fix: use gh source
+- init

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export { lookup } from "https://deno.land/x/media_types@v2.4.1/mod.ts";
+export { lookup } from "https://deno.land/x/media_types@v2.8.1/mod.ts";
 export { parse } from "https://deno.land/x/content_type@1.0.1/mod.ts";
 export { test } from "https://deno.land/x/media_typer@1.0.1/mod.ts";

--- a/readme.md
+++ b/readme.md
@@ -4,13 +4,13 @@
 ![type_is-ci](https://github.com/ako-deno/type_is/workflows/type_is-ci/badge.svg)
 [![HitCount](http://hits.dwyl.com/ako-deno/type_is.svg)](http://hits.dwyl.com/ako-deno/type_is)
 
-Infer the content-type of a HTTP Header for Deno, compatible with Browser. Based on `https://github.com/jshttp/type-is`.
+Infer the content-type of a HTTP Header for Deno, compatible with Browser. Based
+on `https://github.com/jshttp/type-is`.
 
 ## API
 
 ```js
-import { is, typeofrequest, hasBody } from "https://deno.land/x/type_is/mod.ts";
-
+import { hasBody, is, typeofrequest } from "https://deno.land/x/type_is/mod.ts";
 ```
 
 ### is(mediaType: string, types?: string[]): boolean | string
@@ -27,70 +27,70 @@ Each type in the `types` array can be one of the following:
 
 - A file extension name such as `json`. This name will be returned if matched.
 - A mime type such as `application/json`.
-- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`.
-  The full mime type will be returned if matched.
+- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`. The
+  full mime type will be returned if matched.
 - A suffix such as `+json`. This can be combined with a wildcard such as
-  `*/vnd+json` or `application/*+json`. The full mime type will be returned
-  if matched.
+  `*/vnd+json` or `application/*+json`. The full mime type will be returned if
+  matched.
 
 Some examples to illustrate the inputs and returned value:
 
 ```js
-const mediaType = 'application/json'
+const mediaType = "application/json";
 
-is(mediaType, ['json']) // => 'json'
-is(mediaType, ['html', 'json']) // => 'json'
-is(mediaType, ['application/*']) // => 'application/json'
-is(mediaType, ['application/json']) // => 'application/json'
+is(mediaType, ["json"]); // => 'json'
+is(mediaType, ["html", "json"]); // => 'json'
+is(mediaType, ["application/*"]); // => 'application/json'
+is(mediaType, ["application/json"]); // => 'application/json'
 
-is(mediaType, ['html']) // => false
+is(mediaType, ["html"]); // => false
 ```
 
 ### typeofrequest(header: Headers, types?: string[]): null | boolean | string
 
-Checks if the `header` is one of the `types`. If the header's request has no body,
-even if there is a `Content-Type` header, then `null` is returned. If the
+Checks if the `header` is one of the `types`. If the header's request has no
+body, even if there is a `Content-Type` header, then `null` is returned. If the
 `Content-Type` header is invalid or does not matches any of the `types`, then
 `false` is returned. Otherwise, a string of the type that matched is returned.
 
-The `header` argument is expected to be a Deno's Headers, it should be compatible with browser's Headers as well. The `types` argument is an array of type strings.
+The `header` argument is expected to be a Deno's Headers, it should be
+compatible with browser's Headers as well. The `types` argument is an array of
+type strings.
 
 Each type in the `types` array can be one of the following:
 
 - A file extension name such as `json`. This name will be returned if matched.
 - A mime type such as `application/json`.
-- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`.
-  The full mime type will be returned if matched.
+- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`. The
+  full mime type will be returned if matched.
 - A suffix such as `+json`. This can be combined with a wildcard such as
-  `*/vnd+json` or `application/*+json`. The full mime type will be returned
-  if matched.
+  `*/vnd+json` or `application/*+json`. The full mime type will be returned if
+  matched.
 
 Some examples to illustrate the inputs and returned value:
 
 ```js
 const header = new Headers([["content-type", "application/json"]]);
 
-typeis(header, ["json"]) // => "json"
-typeis(header, ["html", "json"]) // => "json"
-typeis(header, ["application/*"]) // => "application/json"
-typeis(header, ["application/json"]) // => "application/json"
-typeis(header, ["html"]) // => false
+typeis(header, ["json"]); // => "json"
+typeis(header, ["html", "json"]); // => "json"
+typeis(header, ["application/*"]); // => "application/json"
+typeis(header, ["application/json"]); // => "application/json"
+typeis(header, ["html"]); // => false
 ```
 
 Example in Deno http server:
 
 ```js
-import {
-  serve
-} from "https://deno.land/std/http/server.ts";
+import { serve } from "https://deno.land/std/http/server.ts";
 import { typeofrequest } from "https://raw.githubusercontent.com/ako-deno/type_is/master/mod.ts";
 
 const server = serve("127.0.0.1:4500");
 
 for await (const req of server) {
-  const isText = typeofrequest(req.headers, ['text/*'])
+  const isText = typeofrequest(req.headers, ["text/*"]);
   const res = {
-    body: `you ${istext ? 'sent' : 'did not send'} me text`,
+    body: `you ${istext ? "sent" : "did not send"} me text`,
     headers: new Headers(),
   };
   req.respond(res).catch(() => {});
@@ -102,8 +102,8 @@ for await (const req of server) {
 Returns a Boolean if the given header's `request` has a body, regardless of the
 `Content-Type` header.
 
-Having a body has no relation to how large the body is (it may be 0 bytes).
-This is similar to how file existence works. If a body does exist, then this
+Having a body has no relation to how large the body is (it may be 0 bytes). This
+is similar to how file existence works. If a body does exist, then this
 indicates that there is data to read from the Deno's request stream.
 
 # License

--- a/test/type_is_test.ts
+++ b/test/type_is_test.ts
@@ -1,7 +1,7 @@
 import {
   assertStrictEquals,
 } from "https://deno.land/std@0.60.0/testing/asserts.ts";
-import { is, typeofrequest, hasBody } from "../mod.ts";
+import { hasBody, is, typeofrequest } from "../mod.ts";
 
 const { test } = Deno;
 


### PR DESCRIPTION
This PR updates dependencies (so [tinyhttp](https://github.com/deno-libs/tinyhttp) can keep using `type_is` without outdated version errors) and runs `deno fmt`